### PR TITLE
Initial Linux support

### DIFF
--- a/launcher/package.json
+++ b/launcher/package.json
@@ -12,6 +12,7 @@
   "repository": "https://github.com/tangobattle/tango",
   "scripts": {
     "build": "npm-run-all build:main build:renderer && ./update-bin.sh",
+    "build:linux": "npm-run-all build:main build:renderer",
     "build:main": "cross-env NODE_ENV=production webpack --config webpack/main.webpack.ts --mode=production",
     "build:renderer": "cross-env NODE_ENV=production webpack --config webpack/renderer.webpack.ts --mode=production",
     "generate:protos": "(mkdir src/protos 2> /dev/null || true) && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=src/protos --ts_proto_opt=esModuleInterop=true -I../core/tango-protos/src/protos ipc.proto lobby.proto relay.proto",
@@ -21,7 +22,8 @@
     "pack": "npm run build && electron-builder --dir",
     "pack:win32-x64": "npm run build && electron-builder --dir --win --x64",
     "dist": "npm run build && electron-builder",
-    "dist:win32-x64": "npm run build && electron-builder --win --x64"
+    "dist:win32-x64": "npm run build && electron-builder --win --x64",
+    "dist:linux": "npm run build:linux && electron-builder"
   },
   "keywords": [],
   "license": "AGPL-3.0",
@@ -94,6 +96,21 @@
     "appId": "com.tangobattle.tango",
     "win": {
       "target": "nsis"
+    },
+    "linux": {
+      "target": [
+        "AppImage"
+      ],
+      "extraFiles": [
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0",
+          "to": "usr/lib/libSDL2-2.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libSDL2_ttf-2.0.so.0",
+          "to": "usr/lib/libSDL2_ttf-2.0.so.0"
+        }
+      ]
     },
     "nsis": {
       "oneClick": false,

--- a/launcher/src/ipc.ts
+++ b/launcher/src/ipc.ts
@@ -52,7 +52,7 @@ export class Core extends EventEmitter {
       ].flat(),
       {
         signal,
-        env,
+        env: { ...process.env, ...env },
       }
     );
 


### PR DESCRIPTION
Most of the stuff breaking Linux support was already fixed thanks to some back and forth on Discord with @bigfarts . This PR mainly just adds some stuff to `package.json` to allow it to build an AppImage with everything it needs.

**Overview of this PR:**
- Added `build:linux` script to `package.json`, which does the build without calling the Windows-specific `update-bin.sh` script
- Added `dist:linux` script to `package.json`, which is identical to `dist` except it calls `build:linux` instead of `build`
- Added a `linux` section to `package.json`, which tells Electron to also copy libSDL2 shared objects from the host to the AppImage, this way the AppImage works fine even if the user's machine doesn't have SDL2 installed
- Ensures `tango-core` is spawned from the launcher while inheriting the full environment. Otherwise it won't be able to find any bundled shared objects and will crash.

**Building:**
- The build process is straightforward, even easier than building for Windows. I believe your workflow already satisfies all the dependencies, it's just a matter of changing some of the commands out. But for completeness, here's what I used to build on a clean Ubuntu 20.04 Docker image:

```
# Update system and install apt dependencies
apt update -y
apt upgrade -y
DEBIAN_FRONTEND=noninteractive apt install -y alsa build-essential clang cmake curl git libnss3 libsdl2-dev libsdl2-ttf-dev pkgconf sudo

# Install Rust, not using apt since apt's version is too old
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

# Install node 18 because apt is on version 12 or something
curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - && \
	sudo apt-get install -y nodejs

# Clone tango
git clone --recurse-submodules https://github.com/tangobattle/tango

# Build the core
cd tango/core
cargo build --release --target x86_64-unknown-linux-gnu

# Copy the core binaries to the launcher
cd ..
mkdir -p launcher/bin
cp core/target/x86_64-unknown-linux-gnu/release/{tango-core,replayview,replaydump,keymaptool} ./launcher/bin/

# Install npm dependencies
cd launcher
npm install

# Build the launcher and package the AppImage
npm run dist:linux

# AppImage will be found at:
# ./packages/Tango-3.1.10.AppImage
```

**Things of note:**
- When packaging this for release, I recommend compiling on Ubuntu 20.04 instead of Ubuntu 22.04. This is so that it gets compiled with a slightly older version of `glibc`, allowing it to run on a wider range of systems. If this were compiled on Ubuntu 22.04, it would only be compatible with a very limited number of systems with the recent version of `glibc` used by 22.04.
- I haven't tested this on an online PvP match at all. The game runs though, so I have no reason to believe the netplay would be broken. Perhaps some beta Linux builds can be released so the wider community can give it a try and report problems.
- For whatever reason (at least on KDE), Tango's icon doesn't show in the application window. Instead, it uses the default placeholder X11 icon. Not a huge deal but I don't know why this is:
![image](https://user-images.githubusercontent.com/3455585/169682529-6633721b-56d9-4d6f-9e64-6527faee7bc4.png)