### PR TITLE
Automatically build for Linux

### DIFF
--- a/.github/workflows/release-linux.yaml
+++ b/.github/workflows/release-linux.yaml
@@ -1,0 +1,52 @@
+name: release-linux
+
+on:
+    push:
+        tags:
+            - "v*.*.*"
+
+jobs:
+    release-linux:
+        runs-on: ubuntu-20.04
+
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: recursive
+
+            - uses: pat-s/always-upload-cache@v2
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      core/target
+                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 18
+
+            - uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+                  target: x86_64-unknown-linux-gnu
+
+            - run: >
+                  sudo apt update -y &&
+                  sudo apt upgrade -y &&
+                  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y alsa build-essential clang cmake curl git libnss3 libsdl2-dev libsdl2-ttf-dev pkgconf sudo
+
+            - run: >
+                  cd core &&
+                  cargo build --release --target x86_64-unknown-linux-gnu
+
+            - run: >
+                  mkdir launcher/bin &&
+                  cp core/target/x86_64-unknown-linux-gnu/release/{tango-core,replayview,replaydump,keymaptool} ./launcher/bin/
+
+            - run: >
+                  cd launcher &&
+                  npm install &&
+                  GITHUB_TOKEN="${{ secrets.github_token }}" USE_HARD_LINKS="false" npm run dist:linux -- --publish always
+              env:
+                  NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/workflows/release-win32-x64.yaml
+++ b/.github/workflows/release-win32-x64.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     release-win32-x64:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/release-win32-x64.yaml
+++ b/.github/workflows/release-win32-x64.yaml
@@ -1,4 +1,4 @@
-name: release
+name: release-win32-x64
 
 on:
     push:

--- a/.github/workflows/release-win32-x64.yaml
+++ b/.github/workflows/release-win32-x64.yaml
@@ -63,6 +63,6 @@ jobs:
             - run: >
                   cd launcher &&
                   npm install &&
-                  GITHUB_TOKEN="${{ secrets.github_token }}" npm run dist:win32-x64 -- --publish always
+                  GITHUB_TOKEN="${{ secrets.github_token }}" USE_HARD_LINKS="false" npm run dist:win32-x64 -- --publish always
               env:
                   NODE_OPTIONS: --max-old-space-size=8192


### PR DESCRIPTION
This PR adds a GitHub Workflow that builds Tango for Linux as an AppImage. It should automatically attach the `.AppImage` to newly tagged releases, just like the Windows workflow already does.

The Windows workflow has been renamed, since it's now not the only one. Both workflows also now target Ubuntu 20.04 specifically, since `ubuntu-latest` is going to be updated to 22.04 any day now, which might be an unexpected change.