### PR TITLE
Build Tango 4 for Linux x86_64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,3 +92,42 @@ jobs:
                   asset_path: ./dist/tango-macos.dmg
                   asset_name: tango-${{ github.ref_name }}-macos.dmg
                   asset_content_type: application/octet-stream
+    release-linux-x86_64:
+        runs-on: ubuntu-20.04 # Ubuntu 20.04 is used for higher glibc compatibility across users
+
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: recursive
+
+            - run: git fetch --tags --force
+
+            - uses: pat-s/always-upload-cache@v2
+              with:
+                  path: |
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      core/target
+                  key: linux-x86_64-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: stable
+                  targets: x86_64-unknown-linux-gnu
+
+            - run: >
+                  sudo apt-get update -y &&
+                  sudo apt-get upgrade -y &&
+                  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y alsa build-essential clang cmake curl fuse git libnss3 librust-atk-dev librust-gdk-pixbuf-dev librust-gdk-sys-dev librust-pango-dev libsdl2-dev pkgconf sudo wget
+
+            - run: >
+                  ./linux/build.sh
+
+            - uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  upload_url: ${{ github.event.release.upload_url }}
+                  asset_path: ./dist/Tango-x86_64-linux.AppImage
+                  asset_name: Tango-x86_64-linux.AppImage
+                  asset_content_type: application/octet-stream

--- a/linux/AppRun
+++ b/linux/AppRun
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+export ARCH="$(uname -m)"
+export PATH="$(pwd)/${ARCH}/bin:${PATH}"
+exec "$(pwd)/${ARCH}/bin/Tango"

--- a/linux/Tango.desktop
+++ b/linux/Tango.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Tango
+Icon=Tango
+Exec=Tango
+Categories=Game;
+Terminal=false

--- a/linux/build.sh
+++ b/linux/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create a basic retry wrapper
+# Use this for anything that makes external network requests
+# This way a single erroneuous network failure doesn't fail the whole build
+retry() {
+	for i in {1..10}; do
+		if [ $i -gt 1 ]; then
+			echo "Retrying... (attempt $i/10)"
+		fi
+
+		$@ || {
+			continue
+		}
+
+		if [[ "$?" == "0" ]]; then
+			return 0
+		fi
+
+		if [ $i -eq 10 ]; then
+			echo "The operation failed after 10 attempts"
+			return 1
+		fi
+	done
+}
+
+# Define the arch we're building for
+# In the future, to build for aarch64, we can re-run all these commands and just change the arch here
+# We would just need to set up an aarch64 sysroot first
+export LINUX_ARCH="x86_64"
+
+# The wget-accessible URL for the static ffmpeg binary
+# Be sure to change to arm64 in the event we want an aarch64 build
+export STATIC_FFMPEG_URL="https://github.com/eugeneware/ffmpeg-static/releases/download/b5.0.1/linux-x64"
+
+# Define a packaging directory
+export LINUX_PACKAGING="linux/packaging"
+
+# Define the ./bin directory inside the AppImage for this arch
+export APPIMAGE_BIN_DIR="${LINUX_PACKAGING}/${LINUX_ARCH}/bin"
+
+# Build Tango
+cargo build --bin tango --target="${LINUX_ARCH}-unknown-linux-gnu" --no-default-features --features=sdl2-audio,wgpu,cpal --release
+
+# Create AppImage packaging directory and a bin folder inside it
+mkdir -p "${APPIMAGE_BIN_DIR}"
+
+# Copy tango icon into packaging directory
+cp tango/src/icon.png "${LINUX_PACKAGING}/Tango.png"
+
+# Copy AppRun into packaging directory and make executable
+cp linux/AppRun "${LINUX_PACKAGING}/AppRun"
+chmod 755 "${LINUX_PACKAGING}/AppRun"
+
+# Copy .desktop file into packaging directory and make executable
+cp linux/Tango.desktop "${LINUX_PACKAGING}/Tango.desktop"
+chmod 755 "${LINUX_PACKAGING}/Tango.desktop"
+
+# Download ffmpeg binary and make executable
+retry wget "${STATIC_FFMPEG_URL}" -O "${APPIMAGE_BIN_DIR}/ffmpeg"
+chmod 755 "${APPIMAGE_BIN_DIR}/ffmpeg"
+
+# Copy Tango binary and make executable
+cp "target/${LINUX_ARCH}-unknown-linux-gnu/release/tango" "${APPIMAGE_BIN_DIR}/Tango"
+chmod 755 "${APPIMAGE_BIN_DIR}/Tango"
+
+# Download appimagetool
+# We don't need to change the arch here for cross compiling, GitHub Actions is x86_64
+retry wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+chmod +x appimagetool-x86_64.AppImage
+
+# Package Tango into an AppImage
+mkdir -p ./dist
+./appimagetool-x86_64.AppImage "${LINUX_PACKAGING}" "./dist/Tango-${LINUX_ARCH}-linux.AppImage"


### PR DESCRIPTION
This PR adds a GitHub Workflow that builds Tango 4 for Linux x86_64 as an AppImage.

Note: Unlike the Windows and Mac versions of Tango, the Linux version does not have an "installer," and therefore runs in place. Since `updater.rs` is configured to _replace_ the `.AppImage`, I decided to set the Workflow property `asset_name` to simply:

`Tango-x86_64-linux.AppImage`

_**Without**_ a version in the filename. This is to avoid situations where the version in the `.AppImage` filename does not match what is actually running after an update. I figure the version number displayed on the release page will be enough to avoid confusion when people are downloading Tango.

The AppImage is not multiarch, however I wrote `build.sh` to be very reusable if you ever wanted to build for `aarch64`. The only additional work that would need to be done is setting up a sysroot for the cross compilation. After that, you simply swap out two variables to build for a different architecture. If an `aarch64` build is ever in demand, maybe we can look at that.

This was tested in an Ubuntu VM and on a Steam Deck, and everything was confirmed working on both - singleplayer, netplay, replays, and exporting.

 It also looks and runs extremely well on a Steam Deck in Game Mode, especially with the new single-window format 👌 